### PR TITLE
♻ 금융 상품 데이터 api custom hook으로 동일 로직 분리

### DIFF
--- a/src/hooks/useFinProducts.ts
+++ b/src/hooks/useFinProducts.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react';
+import ky from 'ky';
+import { FinanceProduct } from '../models/finance-product.interface';
+
+export default function useFinProducts({
+  path,
+  searchParams = {},
+  defaultVisibleCount = 3,
+}: {
+  path: string;
+  searchParams: Record<string, string>;
+  defaultVisibleCount: number;
+}) {
+  const API_URL = `http://localhost:8080/finance/${path}`;
+  const [finProducts, setFinProducts] = useState<FinanceProduct[] | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [visibleCount, setVisibleCount] = useState(defaultVisibleCount);
+
+  const loadMoreProducts = () => {
+    setVisibleCount((prevCount) => prevCount + defaultVisibleCount);
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setIsLoading(true);
+        const response = await ky
+          .get(API_URL, {
+            searchParams,
+          })
+          .json<FinanceProduct[]>();
+
+        setFinProducts(response);
+      } catch (err) {
+        console.error('Failed to fetch data:', err);
+        setError(err instanceof Error ? err : new Error('Unknown error'));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchData();
+  }, [path, searchParams]);
+
+  return {
+    finProducts,
+    error,
+    visibleCount,
+    isLoading,
+    loadMoreProducts,
+  };
+}

--- a/src/hooks/useFinProducts.ts
+++ b/src/hooks/useFinProducts.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import ky from 'ky';
 import { FinanceProduct } from '../models/finance-product.interface';
 
@@ -12,6 +12,11 @@ export default function useFinProducts({
   defaultVisibleCount: number;
 }) {
   const API_URL = `http://localhost:8080/finance/${path}`;
+  const memoizedSearchParams = useMemo(
+    () => searchParams,
+    [JSON.stringify(searchParams)]
+  );
+
   const [finProducts, setFinProducts] = useState<FinanceProduct[] | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -27,7 +32,7 @@ export default function useFinProducts({
         setIsLoading(true);
         const response = await ky
           .get(API_URL, {
-            searchParams,
+            searchParams: memoizedSearchParams,
           })
           .json<FinanceProduct[]>();
 
@@ -40,7 +45,7 @@ export default function useFinProducts({
       }
     };
     fetchData();
-  }, [path, searchParams]);
+  }, [path, memoizedSearchParams]);
 
   return {
     finProducts,

--- a/src/routes/pages/Deposit.tsx
+++ b/src/routes/pages/Deposit.tsx
@@ -1,48 +1,27 @@
-import { useState, useEffect } from 'react';
-import ky from 'ky';
 import Card from '../../components/Card';
-import { FinanceProduct } from '../../models/finance-product.interface';
+import useFinProducts from '../../hooks/useFinProducts';
 
-function Deposit() {
-  const API_URL = 'http://localhost:8080/finance/deposit';
-  const DEFAULT_VISIBLE_COUNT = 3;
-  const [finProducts, setFinProducts] = useState<FinanceProduct[] | null>(null);
-  const [error, setError] = useState<Error | null>(null);
-  const [visibleCount, setVisibleCount] = useState(DEFAULT_VISIBLE_COUNT);
-
-  const loadMoreProducts = () => {
-    setVisibleCount((prevCount) => prevCount + DEFAULT_VISIBLE_COUNT);
-  };
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await ky
-          .get(API_URL, {
-            searchParams: {
-              topFinGrpNo: '020000',
-              pageNo: '1',
-            },
-          })
-          .json<FinanceProduct[]>();
-
-        setFinProducts(response);
-      } catch (err) {
-        console.error('Failed to fetch data:', err);
-        setError(err instanceof Error ? err : new Error('Unknown error'));
-      }
-    };
-    fetchData();
-  }, []);
+export default function Deposit() {
+  const { finProducts, error, visibleCount, isLoading, loadMoreProducts } =
+    useFinProducts({
+      path: 'deposit',
+      searchParams: { topFinGrpNo: '020000', pageNo: '1' },
+      defaultVisibleCount: 3,
+    });
 
   const renderProductList = () => {
     if (error) {
       return <p>Failed to load data: {error.message}</p>;
     }
 
-    if (!finProducts) {
+    if (isLoading) {
       return <p>Loading...</p>;
     }
+
+    if (!finProducts) {
+      return <p>No products available.</p>;
+    }
+
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-4">
         {finProducts.slice(0, visibleCount).map((product) => (
@@ -67,5 +46,3 @@ function Deposit() {
     </>
   );
 }
-
-export default Deposit;


### PR DESCRIPTION
- useFinProducts : api custom hook으로 분리
- memoizedSearchParams : searchParams가 **객체**이기 때문에 참조 비교를 사용, 렌더링 시 **다른 값**으로 간주됨
  - JSON.stringify로 객체 내부 값의 변경 여부 확인, useEffect의 실행을 막음
  - useMemo로 동일 문자열을 참조하도록 설정